### PR TITLE
Fix Yahoo typo

### DIFF
--- a/src/stock_analysis.py
+++ b/src/stock_analysis.py
@@ -87,7 +87,7 @@ class HMMStockPredictor:
 
     @staticmethod
     def _extract_features(data):
-        """Extract the features - open, close, high, low price - from the Yahooo finance generated dataframe."""
+        """Extract the features - open, close, high, low price - from the Yahoo finance generated dataframe."""
         open_price = np.array(data["Open"])
         close_price = np.array(data["Close"])
         high_price = np.array(data["High"])


### PR DESCRIPTION
## Summary
- fix Yahooo typo in `_extract_features` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb29b4c083338709004de47baaf5