### PR TITLE
Add offline DataReader mocks for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
-import pytest 
-import sys 
-import os 
+import pytest
+import os
+import pandas as pd
 
 @pytest.fixture
 def company_name():
@@ -27,6 +27,29 @@ def invalid_start_date():
 @pytest.fixture
 def valid_end_date():
     yield "2020-12-05"
+
+
+@pytest.fixture
+def sample_stock_data():
+    dates = pd.date_range("2020-11-01", periods=5, freq="D")
+    data = {
+        "High": [10, 11, 12, 13, 14],
+        "Low": [5, 5, 6, 6, 7],
+        "Open": [9, 10, 11, 12, 13],
+        "Close": [9, 10, 11, 12, 13],
+        "Volume": [100] * 5,
+        "Adj Close": [9, 10, 11, 12, 13],
+    }
+    return pd.DataFrame(data, index=dates)
+
+
+@pytest.fixture
+def mock_datareader(monkeypatch, sample_stock_data):
+    monkeypatch.setattr(
+        "pandas_datareader.data.DataReader",
+        lambda *args, **kwargs: sample_stock_data.copy(),
+    )
+    yield
 
 
 @pytest.fixture

--- a/tests/large/test_hmm_predictor.py
+++ b/tests/large/test_hmm_predictor.py
@@ -13,7 +13,9 @@ def test_test():
 
 
 @pytest.mark.large
-def test_stock_analysis_record_metrics(company_name, input_args, cleanup_excel_files):
+def test_stock_analysis_record_metrics(
+    company_name, input_args, cleanup_excel_files, mock_datareader
+):
     input_args.append("-m")
     input_args.append("True")
     # Given, when
@@ -31,7 +33,7 @@ def test_stock_analysis_record_metrics(company_name, input_args, cleanup_excel_f
 
 @pytest.mark.large
 def test_stock_analysis_future_predictions(
-    company_name, input_args, cleanup_excel_files
+    company_name, input_args, cleanup_excel_files, mock_datareader
 ):
     input_args.append("-f")
     input_args.append("5")
@@ -50,7 +52,7 @@ def test_stock_analysis_future_predictions(
 
 @pytest.mark.large
 def test_stock_analysis_plot_image(
-    company_name, input_args, cleanup_images, cleanup_excel_files
+    company_name, input_args, cleanup_images, cleanup_excel_files, mock_datareader
 ):
     input_args.append("-m")
     input_args.append("True")

--- a/tests/medium/test_stock_predictor.py
+++ b/tests/medium/test_stock_predictor.py
@@ -8,7 +8,7 @@ from src import stock_analysis
 
 @pytest.mark.medium
 def test_create_stock_predictor_valid_dates(
-    company_name, valid_start_date, valid_end_date
+    company_name, valid_start_date, valid_end_date, mock_datareader
 ):
     # Given
     stock_predictor = stock_analysis.HMMStockPredictor(
@@ -24,7 +24,7 @@ def test_create_stock_predictor_valid_dates(
 
 @pytest.mark.medium
 def test_create_stock_predictor_invalid_dates(
-    company_name, invalid_start_date, valid_end_date
+    company_name, invalid_start_date, valid_end_date, mock_datareader
 ):
     # Given
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- provide pandas-based DataFrame fixture
- add mock to replace `pandas_datareader.data.DataReader`
- use the mock fixture in medium and large tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6844eb287b74833386d5d00e774ac2fb