### PR TITLE
Remove print from medium test

### DIFF
--- a/tests/medium/test_stock_predictor.py
+++ b/tests/medium/test_stock_predictor.py
@@ -1,7 +1,6 @@
 import pytest
 import sys
 
-print(sys.path)
 sys.path.append("../../")
 from src import stock_analysis
 


### PR DESCRIPTION
## Summary
- remove stray print statement in medium test suite

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_6844eb26f61c8333a7689051d53328c7