### PR TITLE
Add scikit-learn requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ hmmlearn
 tqdm
 openpyxl
 pytest
+scikit-learn


### PR DESCRIPTION
## Summary
- add scikit-learn dependency
- ensure `requirements.txt` ends with a newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb10ab888333a4d3d522a180f729