### PR TITLE
Switch stock_analysis to Dockerfile.dev

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: stock_analysis
     build: 
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.dev
     working_dir: /workarea
     
 


### PR DESCRIPTION
## Summary
- adjust docker-compose so stock_analysis service builds with Dockerfile.dev

## Testing
- `docker-compose build` *(fails: docker-compose: command not found)*
- `docker compose build` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f33365288333b319ab7c2683e42d